### PR TITLE
Update README (for env vars)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -29,14 +29,6 @@ ENV DLITE_STORAGES=/app/entities/*.json
 ENV PYTHONPATH=/usr/lib64/python3.9/site-packages
 RUN mkdir -p /app/entities
 
-################# PRODUCTION ####################################
-FROM base as production
-COPY . .
-# Run app
-CMD hypercorn asgi:app --bind 0.0.0.0:8080
-EXPOSE 8080
-
-
 ################# DEVELOPMENT ####################################
 FROM base as development
 COPY . .
@@ -51,4 +43,12 @@ RUN pytest --cov app
 
 # Run with reload option
 CMD hypercorn asgi:app --bind 0.0.0.0:8080 --reload
+EXPOSE 8080
+
+
+################# PRODUCTION ####################################
+FROM base as production
+COPY . .
+# Run app
+CMD hypercorn asgi:app --bind 0.0.0.0:8080
 EXPOSE 8080

--- a/Dockerfile
+++ b/Dockerfile
@@ -29,6 +29,14 @@ ENV DLITE_STORAGES=/app/entities/*.json
 ENV PYTHONPATH=/usr/lib64/python3.9/site-packages
 RUN mkdir -p /app/entities
 
+################# PRODUCTION ####################################
+FROM base as production
+COPY . .
+# Run app
+CMD hypercorn asgi:app --bind 0.0.0.0:8080
+EXPOSE 8080
+
+
 ################# DEVELOPMENT ####################################
 FROM base as development
 COPY . .
@@ -43,12 +51,4 @@ RUN pytest --cov app
 
 # Run with reload option
 CMD hypercorn asgi:app --bind 0.0.0.0:8080 --reload
-EXPOSE 8080
-
-
-################# PRODUCTION ####################################
-FROM base as production
-COPY . .
-# Run app
-CMD hypercorn asgi:app --bind 0.0.0.0:8080
 EXPOSE 8080

--- a/README.md
+++ b/README.md
@@ -54,9 +54,9 @@ docker run \
     --detach \
     --volume ${PWD}:/app \
     --publish 8080:8080 \
-    --env REDIS_TYPE=redis \
-    --env REDIS_HOST=redis \
-    --env REDIS_PORT=6379 \
+    --env OTEAPI_REDIS_TYPE=redis \
+    --env OTEAPI_REDIS_HOST=redis \
+    --env OTEAPI_REDIS_PORT=6379 \
     ontotrans/oteapi-development:latest
 ```
 

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ This requires that the local directory is bind-mounted using the `-v` or `--volu
 To build and run the development target from the command line:
 
 ```shell
-docker build --rm -q -f Dockerfile \
+docker build --rm -f Dockerfile \
     --label "ontotrans.oteapi=development" \
     --target development \
     -t "ontotrans/oteapi-development:latest" .
@@ -22,7 +22,7 @@ Also you might want to use a named container with the `--restart=always` option 
 To build and run the production target from the command line:
 
 ```shell
-docker build --rm -q -f Dockerfile \
+docker build --rm -f Dockerfile \
     --label "ontotrans.oteapi=production" \
     --target production \
     -t "ontotrans/oteapi:latest" .
@@ -88,18 +88,30 @@ To test the data access via SFTP, the atmoz sftp-server can be run:
 
 ```shell
 docker volume create sftpdrive
-docker run \
+PASSWORD="Insert your user password here" docker run \
     --detach \
     --network=otenet \
-    --volume sftpdrive:/home/foo/upload \
+    --volume sftpdrive:${HOME}/download \
     --publish 2222:22 \
-    atmoz/sftp foo:pass:1001
+    atmoz/sftp ${USER}:${PASSWORD}:1001
 ```
 
+For production, SSH public key authentication is preferred.
+
 ## Run with Docker Compose
+
+Prepare the Docker Compose system by running:
 
 ```shell
 docker-compose pull  # Pull the latest images
 docker-compose build  # Build the central OTE service (from Dockerfile)
+```
+
+Now one can simply run:
+
+```shell
 docker-compose up -d  # Run the OTE Services (detached)
 ```
+
+Note that default values will be used if certain environment variables are not present.
+To inspect which environment variables can be specified, please inspect the [Docker Compose file](docker-compose.yml).

--- a/README.md
+++ b/README.md
@@ -24,7 +24,9 @@ To build and run the production target from the command line:
 ```shell
 docker build --rm -q -f Dockerfile \
     --label "ontotrans.oteapi=production" \
+    --target production \
     -t "ontotrans/oteapi:latest" .
+
 ```
 
 ### Run redis
@@ -61,6 +63,24 @@ docker run \
 ```
 
 Open the following URL in a browser [http://localhost:8080/redoc](http://localhost:8080/redoc).
+
+### Run oteapi (production)
+
+Run the services by attaching to the otenet network and set the environmental variables for connecting to Redis.
+
+```shell
+docker run \
+    --rm \
+    --network otenet \
+    --detach \
+    --publish 80:8080 \
+    --env OTEAPI_REDIS_TYPE=redis \
+    --env OTEAPI_REDIS_HOST=redis \
+    --env OTEAPI_REDIS_PORT=6379 \
+    ontotrans/oteapi:latest
+```
+
+Open the following URL in a browser [http://localhost:80/redoc](http://localhost:80/redoc).
 
 ### Run the Atmoz SFTP Server
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,7 +6,7 @@ services:
       context: "."
       target: "${DOCKER_OTEAPI_TARGET:-production}"
     ports:
-      - "${PORT:-80}:8080"
+      - "${PORT:-8080}:8080"
     environment:
       OTEAPI_REDIS_TYPE: redis
       OTEAPI_REDIS_HOST: redis
@@ -19,8 +19,6 @@ services:
 
   redis:
     image: redis:latest
-    expose:
-      - "6379"
     volumes:
       - redis-persist:/data
     networks:
@@ -29,10 +27,8 @@ services:
   sftp:
     image: atmoz/sftp
     volumes:
-      - sftp-storage:/home/foo/upload
-    expose:
-      - "22"
-    command: foo:pass:1001
+      - sftp-storage:${HOME:-/home/foo}/download
+    command: ${USER:-foo}:${PASSWORD:-pass}:1001
     networks:
       - otenet
 


### PR DESCRIPTION
Fixes #12 
~Closes #13~

~It is noted that with the new target order, no tests will be run for the `production` target. Neither during build or during run.
Before, tests would be run during the build, but not when running.~

~There are no changes for `development`.~

Update README.