### PR TITLE
Use oteapi-core v0.0.4

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -29,7 +29,7 @@ invoke==1.6.0
 kombu==5.2.3
 numpy==1.22.1
 openpyxl==3.0.9
-oteapi-core @ git+https://github.com/EMMC-ASBL/oteapi-core.git@master
+oteapi-core==0.0.4
 paramiko==2.9.2
 Pillow==9.0.0
 priority==2.0.0


### PR DESCRIPTION
Closes #17 

Use the official release line of `oteapi-core`, but set it to v0.0.4 for now, since the new plugins submodule is not yet supported in this repository.