### PR TITLE
Update code to be compliant with `oteapi-core` v0.0.5

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -52,11 +52,8 @@ are concrete strategy implementations of the following types:
 - **Filter operation strategy** (defines specify views/operations)
 - **Transformation strategy** (asyncronous operations)
 
-This service is based on:
-
-- **oteapi-core**: v0.0.5
-
-        """,
+This service is based on [**oteapi-core**](https://github.com/EMMC-ASBL/oteapi-core).
+""",
     )
     for router_module in (
         session,

--- a/app/main.py
+++ b/app/main.py
@@ -4,7 +4,7 @@ from typing import TYPE_CHECKING
 from fastapi import FastAPI
 from fastapi.openapi.utils import get_openapi
 from fastapi_plugins import RedisSettings, redis_plugin
-from oteapi.plugins import load_plugins
+from oteapi.plugins import load_strategies
 from pydantic import Field
 
 from app import __version__
@@ -54,7 +54,7 @@ are concrete strategy implementations of the following types:
 
 This service is based on:
 
-- **oteapi-core**: v0.0.3
+- **oteapi-core**: v0.0.5
 
         """,
     )
@@ -109,4 +109,4 @@ _APP.openapi = custom_openapi
 # Events
 _APP.add_event_handler("startup", init_redis)
 _APP.add_event_handler("shutdown", terminate_redis)
-_APP.add_event_handler("startup", load_plugins)
+_APP.add_event_handler("startup", load_strategies)

--- a/app/routers/datafilter.py
+++ b/app/routers/datafilter.py
@@ -6,8 +6,8 @@ from uuid import uuid4
 from aioredis import Redis
 from fastapi import APIRouter, Depends
 from fastapi_plugins import depends_redis
-from oteapi.models.filterconfig import FilterConfig
-from oteapi.plugins.factories import create_filter_strategy
+from oteapi.models import FilterConfig
+from oteapi.plugins import create_strategy
 
 from .session import _update_session, _update_session_list_item
 
@@ -42,7 +42,7 @@ async def get_filter(
 
     filter_info_json = json.loads(await cache.get(filter_id))
     filter_info = FilterConfig(**filter_info_json)
-    filter_strategy = create_filter_strategy(filter_info)
+    filter_strategy = create_strategy("filter", filter_info)
     session_data = None if not session_id else json.loads(await cache.get(session_id))
     result = filter_strategy.get(session_data)
     if result and session_id:
@@ -61,7 +61,7 @@ async def initialize_filter(
 
     filter_info_json = json.loads(await cache.get(filter_id))
     filter_info = FilterConfig(**filter_info_json)
-    filter_strategy = create_filter_strategy(filter_info)
+    filter_strategy = create_strategy("filter", filter_info)
     session_data = None if not session_id else json.loads(await cache.get(session_id))
     result = filter_strategy.initialize(session_data)
     if result and session_id:

--- a/app/routers/mapping.py
+++ b/app/routers/mapping.py
@@ -6,8 +6,8 @@ from uuid import uuid4
 from aioredis import Redis
 from fastapi import APIRouter, Depends
 from fastapi_plugins import depends_redis
-from oteapi.models.mappingconfig import MappingConfig
-from oteapi.plugins.factories import create_mapping_strategy
+from oteapi.models import MappingConfig
+from oteapi.plugins import create_strategy
 
 from .session import _update_session, _update_session_list_item
 
@@ -44,7 +44,7 @@ async def get_mapping(
     mapping_info_json = json.loads(await cache.get(mapping_id))
     mapping_info = MappingConfig(**mapping_info_json)
 
-    mapping_strategy = create_mapping_strategy(mapping_info)
+    mapping_strategy = create_strategy("mapping", mapping_info)
     session_data = None if not session_id else json.loads(await cache.get(session_id))
     result = mapping_strategy.get(session_data)
     if result and session_id:
@@ -63,7 +63,7 @@ async def initialize_mapping(
     mapping_info_json = json.loads(await cache.get(mapping_id))
     mapping_info = MappingConfig(**mapping_info_json)
 
-    mapping_strategy = create_mapping_strategy(mapping_info)
+    mapping_strategy = create_strategy("mapping", mapping_info)
     session_data = None if not session_id else json.loads(await cache.get(session_id))
     result = mapping_strategy.initialize(session_data)
     if result and session_id:

--- a/app/routers/transformation.py
+++ b/app/routers/transformation.py
@@ -6,8 +6,8 @@ from uuid import uuid4
 from aioredis import Redis
 from fastapi import APIRouter, Depends
 from fastapi_plugins import depends_redis
-from oteapi.models.transformationconfig import TransformationConfig
-from oteapi.plugins.factories import create_transformation_strategy
+from oteapi.models import TransformationConfig
+from oteapi.plugins import create_strategy
 
 from .session import _update_session, _update_session_list_item
 
@@ -48,7 +48,7 @@ async def get_transformation_status(
     transformation_info = TransformationConfig(**transformation_info_json)
 
     # Apply the appropriate transformation strategy (plugin) using the factory
-    transformation_strategy = create_transformation_strategy(transformation_info)
+    transformation_strategy = create_strategy("transformation", transformation_info)
 
     status = transformation_strategy.status(task_id)
     return status
@@ -68,7 +68,7 @@ async def get_transformation(
     transformation_info = TransformationConfig(**transformation_info_json)
 
     # Apply the appropriate transformation strategy (plugin) using the factory
-    transformation_strategy = create_transformation_strategy(transformation_info)
+    transformation_strategy = create_strategy("transformation", transformation_info)
 
     session_data = None if not session_id else json.loads(await cache.get(session_id))
     result = transformation_strategy.get(session_data)
@@ -89,8 +89,9 @@ async def execute_transformation(
     transformation_info = json.loads(await cache.get(transformation_id))
 
     # Apply the appropriate transformation strategy (plugin) using the factory
-    transformation_strategy = create_transformation_strategy(
-        TransformationConfig(**transformation_info)
+    transformation_strategy = create_strategy(
+        "transformation",
+        TransformationConfig(**transformation_info),
     )
 
     # If session id is given, pass the object to the strategy create function
@@ -114,8 +115,9 @@ async def initialize_transformation(
     transformation_info = json.loads(await cache.get(transformation_id))
 
     # Apply the appropriate transformation strategy (plugin) using the factory
-    transformation_strategy = create_transformation_strategy(
-        TransformationConfig(**transformation_info)
+    transformation_strategy = create_strategy(
+        "transformation",
+        TransformationConfig(**transformation_info),
     )
 
     # If session id is given, pass the object to the strategy create function

--- a/requirements.txt
+++ b/requirements.txt
@@ -29,7 +29,7 @@ invoke==1.6.0
 kombu==5.2.3
 numpy==1.22.2
 openpyxl==3.0.9
-oteapi-core==0.0.4
+oteapi-core==0.0.5
 paramiko==2.9.2
 Pillow==9.0.1
 priority==2.0.0

--- a/tests/routers/test_transformation.py
+++ b/tests/routers/test_transformation.py
@@ -12,7 +12,7 @@ def test_create_transformation(client: "TestClient") -> None:
     response = client.post(
         "/transformation/",
         json={
-            "transformation_type": "script/dummy",
+            "transformationType": "script/dummy",
             "name": "script/dummy",
             "configuration": {},
         },

--- a/tests/static/test_strategies/download.py
+++ b/tests/static/test_strategies/download.py
@@ -4,7 +4,6 @@ from dataclasses import dataclass
 from typing import TYPE_CHECKING, Optional
 
 from oteapi.datacache.datacache import DataCache
-from oteapi.plugins.factories import StrategyFactory
 from pydantic import BaseModel, Extra, Field
 
 if TYPE_CHECKING:
@@ -27,7 +26,6 @@ class FileConfig(BaseModel):
 
 
 @dataclass
-@StrategyFactory.register(("scheme", "file"))
 class FileStrategy:
     """Strategy for retrieving data via local file."""
 

--- a/tests/static/test_strategies/filter.py
+++ b/tests/static/test_strategies/filter.py
@@ -3,7 +3,6 @@
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, List
 
-from oteapi.plugins.factories import StrategyFactory
 from pydantic import BaseModel, Field
 
 if TYPE_CHECKING:
@@ -19,7 +18,6 @@ class DemoDataModel(BaseModel):
 
 
 @dataclass
-@StrategyFactory.register(("filterType", "filter/demo"))
 class DemoFilter:
     """Filter Strategy."""
 

--- a/tests/static/test_strategies/mapping.py
+++ b/tests/static/test_strategies/mapping.py
@@ -3,8 +3,6 @@
 from dataclasses import dataclass
 from typing import TYPE_CHECKING
 
-from oteapi.plugins.factories import StrategyFactory
-
 if TYPE_CHECKING:
     from typing import Any, Dict, Optional
 
@@ -12,7 +10,6 @@ if TYPE_CHECKING:
 
 
 @dataclass
-@StrategyFactory.register(("mappingType", "mapping/demo"))
 class DemoMappingStrategy:
     """Mapping Strategy."""
 

--- a/tests/static/test_strategies/parse.py
+++ b/tests/static/test_strategies/parse.py
@@ -5,7 +5,7 @@ from dataclasses import dataclass
 from typing import TYPE_CHECKING
 
 from oteapi.datacache.datacache import DataCache
-from oteapi.plugins.factories import StrategyFactory, create_download_strategy
+from oteapi.plugins.factories import create_strategy
 
 if TYPE_CHECKING:
     from typing import Any, Dict, Optional
@@ -14,7 +14,6 @@ if TYPE_CHECKING:
 
 
 @dataclass
-@StrategyFactory.register(("mediaType", "text/json"))
 class DemoJSONDataParseStrategy:
     """Parse Strategy."""
 
@@ -28,7 +27,7 @@ class DemoJSONDataParseStrategy:
 
     def parse(self, session: "Optional[Dict[str, Any]]" = None) -> "Dict[str, Any]":
         """Parse json."""
-        downloader = create_download_strategy(self.resource_config)
+        downloader = create_strategy("download", self.resource_config)
         output = downloader.get()
         cache = DataCache(self.resource_config.configuration)
         content = cache.get(output["key"])

--- a/tests/static/test_strategies/resource.py
+++ b/tests/static/test_strategies/resource.py
@@ -3,7 +3,7 @@
 from dataclasses import dataclass
 from typing import TYPE_CHECKING
 
-from oteapi.plugins.factories import StrategyFactory, create_download_strategy
+from oteapi.plugins.factories import create_strategy
 
 if TYPE_CHECKING:
     from typing import Any, Dict, Optional
@@ -12,7 +12,6 @@ if TYPE_CHECKING:
 
 
 @dataclass
-@StrategyFactory.register(("accessService", "demo-access-service"))
 class DemoResourceStrategy:
     """Resource Strategy."""
 
@@ -27,6 +26,6 @@ class DemoResourceStrategy:
     def get(self, session: "Optional[Dict[str, Any]]" = None) -> "Dict[str, Any]":
         """Manage mapping and return shared map"""
         # Example of the plugin using the download strategy to fetch the data
-        download_strategy = create_download_strategy(self.resource_config)
+        download_strategy = create_strategy("download", self.resource_config)
         read_output = download_strategy.get(session)
         return {"output": read_output}

--- a/tests/static/test_strategies/transformation.py
+++ b/tests/static/test_strategies/transformation.py
@@ -5,7 +5,6 @@ from datetime import datetime
 from typing import TYPE_CHECKING
 
 from oteapi.models.transformationconfig import TransformationStatus
-from oteapi.plugins.factories import StrategyFactory
 
 if TYPE_CHECKING:
     from typing import Any, Dict, Optional
@@ -14,7 +13,6 @@ if TYPE_CHECKING:
 
 
 @dataclass
-@StrategyFactory.register(("transformation_type", "script/demo"))
 class DummyTransformationStrategy:
     """Transformation Strategy."""
 


### PR DESCRIPTION
Use `create_strategy()` throughout and `load_strategies()`.

For the testing, a new utility function to load the test strategies
under `tests/static/strategies/` has to be added.

Update `oteapi-core` dependency to v0.0.5.

Fixes #36 