### PR TITLE
Bumped required version of oteapi-core up to 0.0.6

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -29,7 +29,7 @@ invoke==1.6.0
 kombu==5.2.3
 numpy==1.22.2
 openpyxl==3.0.9
-oteapi-core==0.0.5
+oteapi-core==0.0.6
 paramiko==2.9.2
 Pillow==9.0.1
 priority==2.0.0


### PR DESCRIPTION
A bug resulting in `TypeError: 'DataCacheConfig' object is not subscriptable` was solved in oteapi-core v0.0.6.
Updating the dependency to this version should resolve the issue in otelib.
