### PR TITLE
Remove checkboxes from `requirements.txt` update PR body

### DIFF
--- a/.github/utils/requirements_update_pr_body.txt
+++ b/.github/utils/requirements_update_pr_body.txt
@@ -1,8 +1,3 @@
 ### Update `requirements.txt`
 
 Automatically created PR from the [`ci_update_requirements.yml` workflow](https://github.com/EMMC-ASBL/oteapi-services/blob/master/.github/workflows/ci_update_requirements.yml).
-
-#### To-do
-
-- [ ] Check that the diff is sensible, and that tests and builds pass with the new dependency versions.
-- [ ] Make sure that the PR is **squash** merged, with a sensible commit message.

--- a/.github/workflows/ci_dependabot.yml
+++ b/.github/workflows/ci_dependabot.yml
@@ -6,6 +6,7 @@ on:
     # Dependabot runs once a week (every Monday) (pip)
     # and every day (GH Actions) between 7:00 and 7:30 (5:00-5:30 UTC)
     - cron: "30 6 * * 3"
+  workflow_dispatch:
 
 jobs:
   create-collected-pr:
@@ -26,7 +27,7 @@ jobs:
     - name: Set up Python 3.9
       uses: actions/setup-python@v2
       with:
-        python-version: 3.9
+        python-version: "3.9"
 
     - name: Install `pre-commit` and dependencies
       run: |

--- a/.github/workflows/ci_update_requirements.yml
+++ b/.github/workflows/ci_update_requirements.yml
@@ -4,6 +4,7 @@ on:
   schedule:
     # At 7:30 every Monday (6:30 UTC)
     - cron: "30 6 * * 1"
+  workflow_dispatch:
 
 env:
   DEPENDABOT_BRANCH: ci/dependabot-updates
@@ -26,7 +27,7 @@ jobs:
     - name: Set up Python 3.9
       uses: actions/setup-python@v2
       with:
-        python-version: 3.9
+        python-version: "3.9"
 
     - name: Set up git config
       run: |


### PR DESCRIPTION
Fixes #60 

Also makes it possible to manually start the CI workflows for creating PRs - both for updating `requirements.txt` as well as for merging the `ci/dependency-updates` branch into `master`.