### PR TITLE
Use an entrypoint script for the Dockerfile

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -565,3 +565,6 @@ MigrationBackup/
 
 # Git
 *.orig
+
+# From docker build
+constraints.txt

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,7 @@ WORKDIR /app
 
 # Copy core parts and install requirements
 COPY app app/
-COPY requirements.txt LICENSE README.md asgi.py ./
+COPY requirements.txt LICENSE README.md asgi.py entrypoint.sh ./
 RUN apt-get update \
   && apt-get -y install --fix-broken --fix-missing --no-install-recommends git \
   && apt-get purge -y --auto-remove \
@@ -36,11 +36,13 @@ RUN pip install --trusted-host pypi.org --trusted-host files.pythonhosted.org -r
 
 # Run app with reload option
 EXPOSE 8080
-CMD if [ "${PATH_TO_OTEAPI_CORE}" != "/dev/null" ] && [ -n "${PATH_TO_OTEAPI_CORE}" ]; then pip install -U --force-reinstall -e /oteapi_core; fi && hypercorn asgi:app --bind 0.0.0.0:8080 --reload --debug --log-level debug
+CMD if [ "${PATH_TO_OTEAPI_CORE}" != "/dev/null" ] && [ -n "${PATH_TO_OTEAPI_CORE}" ]; then \
+  pip install -U --force-reinstall -c requirements.txt -e /oteapi_core; fi \
+  && ./entrypoint.sh --reload --debug --log-level debug
 
 ################# PRODUCTION #####################################
 FROM base as production
 
 # Run app
 EXPOSE 8080
-CMD hypercorn asgi:app --bind 0.0.0.0:8080
+ENTRYPOINT [ "./entrypoint.sh" ]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,6 +10,7 @@ services:
       OTEAPI_REDIS_HOST: redis
       OTEAPI_REDIS_PORT: 6379
       OTEAPI_prefix: "${OTEAPI_prefix:-/api/v1}"
+      OTEAPI_PLUGIN_PACKAGES:
     depends_on:
       - redis
     networks:

--- a/docker-compose_dev.yml
+++ b/docker-compose_dev.yml
@@ -12,6 +12,7 @@ services:
       OTEAPI_REDIS_HOST: redis
       OTEAPI_REDIS_PORT: 6379
       OTEAPI_prefix: "${OTEAPI_prefix:-/api/v1}"
+      OTEAPI_PLUGIN_PACKAGES:
       PATH_TO_OTEAPI_CORE: "${PATH_TO_OTEAPI_CORE:-/dev/null}"
     depends_on:
       - redis

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+# Bash script to run upon starting the Dockerfile.
+# The purpose of this script is to install desired plugin packages.
+# Only packages that support the current list of pinned requirements version are
+# installed, see `requirements.txt`.
+#
+# Any extra parameters supplied to this script will be passed on to `hypercorn`.
+# This is relevant for, e.g., the `development` target.
+set -e
+
+# If a custom `oteapi-core` version is installed, the package versions may differ from
+# those given in `requirements.txt`. To work around this, we store the currently
+# packages in a `constraints.txt` file to be used as a hard constraint when installing
+# the plugin packages. I.e., the plugin packages cannot change the versions of the
+# already installed packages.
+pip list --format=freeze --include-editable --not-required > constraints.txt
+
+if [ -n "${OTEAPI_PLUGIN_PACKAGES}" ]; then
+    echo "Installing plugins:"
+    for plugin in ${OTEAPI_PLUGIN_PACKAGES}; do echo "* ${plugin}"; done
+    for plugin in ${OTEAPI_PLUGIN_PACKAGES}; do pip install -q -c constraints.txt ${plugin} || continue; done
+else
+    echo "No extra plugin packages provided. Specify 'OTEAPI_PLUGIN_PACKAGES' to specify plugin packages."
+fi
+
+hypercorn asgi:app --bind 0.0.0.0:8080 $@

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -8,17 +8,27 @@
 # This is relevant for, e.g., the `development` target.
 set -e
 
-# If a custom `oteapi-core` version is installed, the package versions may differ from
-# those given in `requirements.txt`. To work around this, we store the currently
-# packages in a `constraints.txt` file to be used as a hard constraint when installing
-# the plugin packages. I.e., the plugin packages cannot change the versions of the
+# If a custom `oteapi-core` version is installed, the version for it may differ from
+# that given in `requirements.txt`. To work around this, we copy the `requirements.txt`
+# file into a `constraints.txt` file and replace the `oteapi-core` version there with
+# the one currently installed. The `constraints.txt` file is then used as a hard
+# constraint when installing the plugin packages. I.e., the plugin packages cannot change the versions of the
 # already installed packages.
-pip list --format=freeze --include-editable --not-required > constraints.txt
+oteapi_core_requirement="$(pip list --format=freeze --include-editable | grep 'oteapi-core')"
+sed -E -e "s|oteapi-core==[0-9.]+|${oteapi_core_requirement}|" requirements.txt > constraints.txt
 
 if [ -n "${OTEAPI_PLUGIN_PACKAGES}" ]; then
     echo "Installing plugins:"
+    # Print out list of plugins in separate for-loop to avoid `pip` message interjections
     for plugin in ${OTEAPI_PLUGIN_PACKAGES}; do echo "* ${plugin}"; done
     for plugin in ${OTEAPI_PLUGIN_PACKAGES}; do pip install -q -c constraints.txt ${plugin} || continue; done
+    current_packages="$(pip freeze)"
+    for plugin in ${OTEAPI_PLUGIN_PACKAGES}; do
+        if [[ "${current_package}" != *"${plugin}"* ]]; then
+            echo "One or more plugin packages failed to install. See above for more information."
+            exit 1
+        fi
+    done
 else
     echo "No extra plugin packages provided. Specify 'OTEAPI_PLUGIN_PACKAGES' to specify plugin packages."
 fi


### PR DESCRIPTION
Closes #72 

This enables a more sophisticated way of installing plugin packages.

To accommodate the `development` target, when installing a custom/editable/local version of `oteapi-core`, and list of package constraints is made on-the-fly.

---

To do:
- [x] Document method of installing plugin packages.
- [ ] _(To be discussed and agreed upon in the comments of this PR)_ Determine proper way of creating the list of package constraints (the `constraints.txt` file).