### PR TITLE
New plugin package delimiter: A colon (`:`)

### DIFF
--- a/.github/utils/docker-compose_ci_plugins.yml
+++ b/.github/utils/docker-compose_ci_plugins.yml
@@ -1,0 +1,43 @@
+version: "3"
+
+services:
+  oteapi:
+    image: ghcr.io/emmc-asbl/oteapi:${DOCKER_OTEAPI_VERSION:-latest}
+    ports:
+      - "${PORT:-8080}:8080"
+    environment:
+      OTEAPI_REDIS_TYPE: redis
+      OTEAPI_REDIS_HOST: redis
+      OTEAPI_REDIS_PORT: 6379
+      OTEAPI_prefix: "${OTEAPI_prefix:-/api/v1}"
+      OTEAPI_PLUGIN_PACKAGES:
+      PATH_TO_OTEAPI_CORE: "${PATH_TO_OTEAPI_CORE:-/dev/null}"
+    depends_on:
+      - redis
+    networks:
+      - otenet
+    volumes:
+      - "${LOCAL_TARGET_PLUGIN_PATH}:/oteapi-core"
+      - "${PATH_TO_OTEAPI_CORE:-/dev/null}:/oteapi_core"
+
+  redis:
+    image: redis:latest
+    volumes:
+      - redis-persist:/data
+    networks:
+      - otenet
+
+  sftp:
+    image: atmoz/sftp
+    volumes:
+      - sftp-storage:${HOME:-/home/foo}/download
+    command: ${USER:-foo}:${PASSWORD:-pass}:1001
+    networks:
+      - otenet
+
+volumes:
+  redis-persist:
+  sftp-storage:
+
+networks:
+  otenet:

--- a/.github/workflows/ci_tests.yml
+++ b/.github/workflows/ci_tests.yml
@@ -128,6 +128,11 @@ jobs:
       matrix:
         docker-target: ["development", "production"]
 
+    env:
+      PORT: 8123
+      OTEAPI_prefix: /api/ci/v1
+      DOCKER_OTEAPI_TARGET: ${{ matrix.docker-target }}
+
     steps:
     - uses: actions/checkout@v3
 
@@ -144,10 +149,6 @@ jobs:
         .github/utils/wait_for_it.sh localhost:${{ env.PORT }} -t 120
         sleep 5
         curl -X "GET" -i "http://localhost:${{ env.PORT }}${{ env.OTEAPI_prefix }}/session"
-      env:
-        PORT: 8123
-        OTEAPI_prefix: /api/ci/v1
-        DOCKER_OTEAPI_TARGET: ${{ matrix.docker-target }}
 
     - name: Start the Docker services with local `oteapi-core`
       if: matrix.docker-target == 'development'
@@ -161,7 +162,37 @@ jobs:
         sleep 40
         curl -X "GET" -i "http://localhost:${{ env.PORT }}${{ env.OTEAPI_prefix }}/session"
       env:
-        PORT: 8123
-        OTEAPI_prefix: /api/ci/v1
-        DOCKER_OTEAPI_TARGET: ${{ matrix.docker-target }}
         PATH_TO_OTEAPI_CORE: /tmp/oteapi-core
+
+  docker-compose-plugins:
+    name: docker-compose - plugin test
+    runs-on: ubuntu-latest
+
+    env:
+      PORT: 8125
+      OTEAPI_prefix: /api/ci_plugins/v1
+      LOCAL_TARGET_PLUGIN_PATH: /tmp/oteapi-core
+
+    steps:
+    - uses: actions/checkout@v3
+
+    - name: Install Docker-Compose v2
+      run: |
+        # Need to re-install docker-compose from pip:
+        # https://github.com/docker/compose/issues/7686
+        sudo apt-get update && sudo pip install docker-compose
+
+    - name: Clone `oteapi-core` locally as "plugin"
+      run: git clone https://github.com/EMMC-ASBL/oteapi-core ${LOCAL_TARGET_PLUGIN_PATH}
+
+    - name: Start the Docker services
+      run: |
+        docker-compose -f .github/utils/docker-compose_ci_plugin.yml pull
+        docker-compose -f .github/utils/docker-compose_ci_plugin.yml --verbose -- up &
+        .github/utils/wait_for_it.sh localhost:${{ env.PORT }} -t 120
+        # Sleep for longer, since it takes a while to install `oteapi-core`
+        # And the port will be available as soon as the CMD is reached in the Dockerfile.
+        sleep 40
+        curl -X "GET" -i "http://localhost:${{ env.PORT }}${{ env.OTEAPI_prefix }}/session"
+      env:
+        OTEAPI_PLUGIN_PACKAGES: "-v -e /oteapi-core[dev]:oteapi-dlite"

--- a/README.md
+++ b/README.md
@@ -164,18 +164,43 @@ To use OTEAPI strategies other than those included in [OTEAPI Core](https://emmc
 Currently, there is no index of available plugins, however, there might be in the future.
 
 To install OTEAPI plugin packages for use in the OTEAPI service, one needs to specify the `OTEAPI_PLUGIN_PACKAGES` environment variable when running the service through either [Docker](#run-in-docker) or [Docker Compose](#run-with-docker-compose).
-The variable should be a space-separated string of each package name, possibly including a version range for the given package.
+The variable should be a colon-separated (`:`) string of each package name, possibly including a version range for the given package.
 
 For example, to install the packages `oteapi-plugin` and `my_special_plugin` one could specify `OTEAPI_PLUGIN_PACKAGES` in the following way:
 
 ```shell
-OTEAPI_PLUGIN_PACKAGES="oteapi-plugin my_special_plugin"
+OTEAPI_PLUGIN_PACKAGES="oteapi-plugin:my_special_plugin"
 ```
 
 Should there be special version constraints for the packages, these can be added after the package name, separated by commas:
 
 ```shell
-OTEAPI_PLUGIN_PACKAGES="oteapi-plugin~=1.3 my_special_plugin>=2.1.1,<3,!=2.1.0"
+OTEAPI_PLUGIN_PACKAGES="oteapi-plugin~=1.3:my_special_plugin>=2.1.1,<3,!=2.1.0"
 ```
 
 To ensure this variable is used when running the service you could either `export` it, set it in the same command line as running the service, or define it in a separate file, telling `docker` or `docker-compose` to use this file as a source of environment variables through the `--env-file` option.
+
+### For plugin developers
+
+This environment variable allows you to pass _any_ parameters and values to `pip install`, hence you could map a local folder for your plugin repository into the container and use the full path within the container to install the plugin.
+
+If passing it with the `-e` option, it will be an editable installation.
+This means any changes in the plugin will be echoed in the service as soon as the file is stored to disk and hypercorn has reloaded.
+
+Example:
+
+```shell
+OTEAPI_PLUGIN_PACKAGES="oteapi-plugin~=1.3:my_special_plugin>=2.1.1,<3,!=2.1.0:-v -e /oteapi-plugin-dev[dev]"
+```
+
+Here, the constant `-q` (silent) option for `pip install` has been reversed by using the `-v` (verbose) option, and the package at `/oteapi-plugin-dev` within the container is being installed as an editable installation, including the `dev` extra.
+
+Now in the local `docker-compose.yml` file, one would need to add:
+
+```yaml
+- "${PWD}:/oteapi-plugin-dev"
+```
+
+Under `volumes` under `oteapi`.
+Assuming the `docker-compose.yml` file in question is placed in the root of the plugin repository.
+If not, the first part (`${PWD}`) should be changed accordingly.

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -20,6 +20,7 @@ sed -E -e "s|oteapi-core==[0-9.]+|${oteapi_core_requirement}|" requirements.txt 
 if [ -n "${OTEAPI_PLUGIN_PACKAGES}" ]; then
     echo "Installing plugins:"
     # Print out list of plugins in separate for-loop to avoid `pip` message interjections
+    IFS=":"
     for plugin in ${OTEAPI_PLUGIN_PACKAGES}; do echo "* ${plugin}"; done
     for plugin in ${OTEAPI_PLUGIN_PACKAGES}; do pip install -q -c constraints.txt ${plugin} || continue; done
     current_packages="$(pip freeze)"


### PR DESCRIPTION
Closes #76 
Closes #77 

Test using the new delimiter, adding `pip install` options and local paths mapped into the container.