### PR TITLE
Use pipe (`|`) instead of colon (`:`) for plugins

### DIFF
--- a/.github/workflows/ci_tests.yml
+++ b/.github/workflows/ci_tests.yml
@@ -179,5 +179,5 @@ jobs:
         curl -X "GET" -i "http://localhost:${{ env.PORT }}${{ env.OTEAPI_prefix }}/session"
       env:
         CONTAINER_PLUGIN_PATH: /special-plugin
-        OTEAPI_PLUGIN_PACKAGES: "-v -e /special-plugin[dev]:oteapi-dlite"
+        OTEAPI_PLUGIN_PACKAGES: "-v -e /special-plugin[dev]|oteapi-dlite"
         LOCAL_TARGET_PLUGIN_PATH: ${{ env.LOCAL_OTEAPI_PATH }}

--- a/README.md
+++ b/README.md
@@ -164,18 +164,18 @@ To use OTEAPI strategies other than those included in [OTEAPI Core](https://emmc
 Currently, there is no index of available plugins, however, there might be in the future.
 
 To install OTEAPI plugin packages for use in the OTEAPI service, one needs to specify the `OTEAPI_PLUGIN_PACKAGES` environment variable when running the service through either [Docker](#run-in-docker) or [Docker Compose](#run-with-docker-compose).
-The variable should be a colon-separated (`:`) string of each package name, possibly including a version range for the given package.
+The variable should be a pipe-separated (`|`) string of each package name, possibly including a version range for the given package.
 
 For example, to install the packages `oteapi-plugin` and `my_special_plugin` one could specify `OTEAPI_PLUGIN_PACKAGES` in the following way:
 
 ```shell
-OTEAPI_PLUGIN_PACKAGES="oteapi-plugin:my_special_plugin"
+OTEAPI_PLUGIN_PACKAGES="oteapi-plugin|my_special_plugin"
 ```
 
 Should there be special version constraints for the packages, these can be added after the package name, separated by commas:
 
 ```shell
-OTEAPI_PLUGIN_PACKAGES="oteapi-plugin~=1.3:my_special_plugin>=2.1.1,<3,!=2.1.0"
+OTEAPI_PLUGIN_PACKAGES="oteapi-plugin~=1.3|my_special_plugin>=2.1.1,<3,!=2.1.0"
 ```
 
 To ensure this variable is used when running the service you could either `export` it, set it in the same command line as running the service, or define it in a separate file, telling `docker` or `docker-compose` to use this file as a source of environment variables through the `--env-file` option.
@@ -197,7 +197,7 @@ This means any changes in the plugin will be echoed in the service as soon as th
 Example:
 
 ```shell
-OTEAPI_PLUGIN_PACKAGES="oteapi-plugin~=1.3:my_special_plugin>=2.1.1,<3,!=2.1.0:-v -e /oteapi-plugin-dev[dev]"
+OTEAPI_PLUGIN_PACKAGES="oteapi-plugin~=1.3|my_special_plugin>=2.1.1,<3,!=2.1.0|-v -e /oteapi-plugin-dev[dev]"
 ```
 
 Here, the constant `-q` (silent) option for `pip install` has been reversed by using the `-v` (verbose) option, and the package at `/oteapi-plugin-dev` within the container is being installed as an editable installation, including the `dev` extra.

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -20,7 +20,7 @@ sed -E -e "s|oteapi-core==[0-9.]+|${oteapi_core_requirement}|" requirements.txt 
 if [ -n "${OTEAPI_PLUGIN_PACKAGES}" ]; then
     echo "Installing plugins:"
     # Print out list of plugins in separate for-loop to avoid `pip` message interjections
-    IFS=":"
+    IFS="|"
     for plugin in ${OTEAPI_PLUGIN_PACKAGES}; do echo "* ${plugin}"; done
     for plugin in ${OTEAPI_PLUGIN_PACKAGES}; do eval "pip install -q -c constraints.txt ${plugin}" || FAILED_PLUGIN_INSTALLS=${FAILED_PLUGIN_INSTALLS:+$FAILED_PLUGIN_INSTALLS:}${plugin} && continue; done
     current_packages="$(pip freeze)"


### PR DESCRIPTION
Fixes #81 