### PR TITLE
Use new environment files for set output

### DIFF
--- a/.github/workflows/ci_cd_updated_master.yml
+++ b/.github/workflows/ci_cd_updated_master.yml
@@ -57,7 +57,7 @@ jobs:
         fi
 
         echo "CONTINUE_WORKFLOW=${CONTINUE_WORKFLOW}" >> $GITHUB_ENV
-        echo "::set-output name=continue_workflow::${CONTINUE_WORKFLOW}"
+        echo "continue_workflow=${CONTINUE_WORKFLOW}" >> $GITHUB_OUTPUT
 
     - name: Update changelog
       if: env.CONTINUE_WORKFLOW == 'true'


### PR DESCRIPTION
# Description:

See https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/ for more information about the new environment file usage instead of the now deprecated `set-output` (and `save-state`) commands.

Closes #233 

## Type of change:
<!-- Put an `x` in the box that applies. -->
- [x] Bug fix (sort of).
- [ ] New feature.
- [ ] Documentation update.

## Checklist for the reviewer:
<!-- Put an `x` in the boxes that apply. These can be filled by reviewer after the PR is created. -->

This checklist should be used as a help for the reviewer.

- [x] Is the change limited to one issue?
- [x] Does this PR close the issue?
- [x] Is the code easy to read and understand?
- [x] Do all new feature have an accompanying new test?
- [x] Has the documentation been updated as necessary?
