### PR TITLE
Cache only the set parameters in the configurations

### DIFF
--- a/app/routers/dataresource.py
+++ b/app/routers/dataresource.py
@@ -55,9 +55,10 @@ async def create_dataresource(
     """
     new_resource = CreateResourceResponse()
 
-    config.token = request.headers.get("Authorization") or config.token
+    if request.headers.get("Authorization") or config.token:
+        config.token = request.headers.get("Authorization") or config.token
 
-    resource_config = config.model_dump_json()
+    resource_config = config.model_dump_json(exclude_unset=True)
 
     await cache.set(new_resource.resource_id, resource_config)
 

--- a/app/routers/function.py
+++ b/app/routers/function.py
@@ -39,9 +39,10 @@ async def create_function(
     """Create a new function configuration."""
     new_function = CreateFunctionResponse()
 
-    config.token = request.headers.get("Authorization") or config.token
+    if request.headers.get("Authorization") or config.token:
+        config.token = request.headers.get("Authorization") or config.token
 
-    function_config = config.model_dump_json()
+    function_config = config.model_dump_json(exclude_unset=True)
 
     await cache.set(new_function.function_id, function_config)
 

--- a/app/routers/transformation.py
+++ b/app/routers/transformation.py
@@ -40,9 +40,10 @@ async def create_transformation(
     """Create a new transformation configuration."""
     new_transformation = CreateTransformationResponse()
 
-    config.token = request.headers.get("Authorization") or config.token
+    if request.headers.get("Authorization") or config.token:
+        config.token = request.headers.get("Authorization") or config.token
 
-    transformation_config = config.model_dump_json()
+    transformation_config = config.model_dump_json(exclude_unset=True)
 
     await cache.set(new_transformation.transformation_id, transformation_config)
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -38,7 +38,7 @@ else
 fi
 
 if [ "${DEV_ENV}" == "1" ] && [ "${CI}" == "" ]; then
-    python -m debugpy --wait-for-client --listen 0.0.0.0:5678 -m hypercorn --bind 0.0.0.0:8080 asgi:app "$@"
+    python -m debugpy --listen 0.0.0.0:5678 -m hypercorn --bind 0.0.0.0:8080 asgi:app "$@"
 else
     hypercorn --bind 0.0.0.0:8080 asgi:app "$@"
 fi


### PR DESCRIPTION
# Description:
<!-- Summary of change, including the issue to be addressed. -->
In order to properly be able to determine what values were set by the user and what are given defaults or just simply available keys set to `None`, strategy configurations should be stored after dumping/serializing it from a pydantic model via the `exclude_unset=True` option.

Also, avoid setting the `token` parameter if there is no reason to. Also, remove the `--wait-for-client` option when running the service via `debugpy`. This will avoid running the server as long as VS Code has not started a session. If this is specifically necessary, e.g., when debugging startup events, then this can be added in locally.

This is related to EMMC-ASBL/otelib#178 and EMMC-ASBL/otelib#174.

## Type of change:
<!-- Put an `x` in the box that applies. -->
- [x] Bug fix.
- [ ] New feature.
- [ ] Documentation update.

## Checklist for the reviewer:
<!-- Put an `x` in the boxes that apply. These can be filled by reviewer after the PR is created. -->

This checklist should be used as a help for the reviewer.

- [ ] Is the change limited to one issue?
- [ ] Does this PR close the issue?
- [ ] Is the code easy to read and understand?
- [ ] Do all new feature have an accompanying new test?
- [ ] Has the documentation been updated as necessary?
