### PR TITLE
Fix CD release: use new commit instead of force-push to update master

### DIFF
--- a/.github/workflows/cd_release.yml
+++ b/.github/workflows/cd_release.yml
@@ -70,7 +70,7 @@ jobs:
       if: steps.update_version_step.outputs.continue_workflow == 'true'
       run: |
         git add app/__init__.py CHANGELOG.md
-        git commit --amend -C HEAD
+        git commit -m "[bot] Update version and CHANGELOG"
 
     - name: Update '${{ env.DEFAULT_REPO_BRANCH }}'
       if: steps.update_version_step.outputs.continue_workflow == 'true'
@@ -79,7 +79,7 @@ jobs:
         token: ${{ secrets.RELEASE_PAT }}
         branch: ${{ env.DEFAULT_REPO_BRANCH }}
         pre_sleep: 15
-        force: true
+        force: false
         unprotect_reviews: true
 
   publish_container_image:

--- a/.github/workflows/cd_release.yml
+++ b/.github/workflows/cd_release.yml
@@ -70,7 +70,7 @@ jobs:
       if: steps.update_version_step.outputs.continue_workflow == 'true'
       run: |
         git add app/__init__.py CHANGELOG.md
-        git commit -m "[bot] Update version and CHANGELOG"
+        git commit -m "[bot] Update version and CHANGELOG [skip ci]"
 
     - name: Update '${{ env.DEFAULT_REPO_BRANCH }}'
       if: steps.update_version_step.outputs.continue_workflow == 'true'

--- a/.github/workflows/cd_release.yml
+++ b/.github/workflows/cd_release.yml
@@ -78,9 +78,9 @@ jobs:
       with:
         token: ${{ secrets.RELEASE_PAT }}
         branch: ${{ env.DEFAULT_REPO_BRANCH }}
-        sleep: 15
+        pre_sleep: 15
         force: true
-        unprotect_reviews: false
+        unprotect_reviews: true
 
   publish_container_image:
     name: Publish Container image on GH Packages

--- a/.gitignore
+++ b/.gitignore
@@ -570,3 +570,5 @@ MigrationBackup/
 constraints.txt
 
 .*_cache/
+
+.claude/


### PR DESCRIPTION
## Summary

The `cd_release.yml` workflow has been failing on every push to `master` since ~December 2025.

**Root cause:** The workflow amends the last commit (version bump + CHANGELOG) and then uses `push-protected` with `force: true`. Master's branch protection now has `allow_force_pushes: false`, so every force-push is rejected with `GH006`/`GH013`. The `push-protected@v2` action's `unprotect_reviews` only removes `required_pull_request_reviews` — it does not touch `allow_force_pushes`.

**Fix:** Replace `git commit --amend -C HEAD` with a plain `git commit`, so the local branch is simply one commit ahead of `origin/master` (fast-forward). Set `force: false` in the `push-protected` step. Also update the deprecated `sleep` input to `pre_sleep`, enable `unprotect_reviews: true` to temporarily lift the PR-review requirement during the push, and add `[skip ci]` to the commit message so it does not trigger redundant workflow runs.

## Trade-offs

- **Two commits per version bump instead of one.** Previously the PR merge commit was amended in-place; now a separate `[bot] Update version and CHANGELOG [skip ci]` commit follows it. The `[skip ci]` token prevents any workflows from being triggered by that push, so there is no extra CI or CD run.

## Verification

Watch the next push to `master` — the `CD - Release` workflow should pass its `Update 'master'` step and create the `[bot] Update version and CHANGELOG [skip ci]` commit on `master`.

<details>
<summary>Click to view squash commit message</summary>

> Fix cd_release.yml: use a new commit and non-force push
>
> Branch protection on master has `allow_force_pushes: false`. The workflow
> was amending the last commit then force-pushing via push-protected,
> causing all CD runs to fail since ~December 2025.
>
> Fix by creating a plain new commit (fast-forward) and setting `force: false`
> in push-protected. Also update the deprecated `sleep` input to `pre_sleep`
> and enable `unprotect_reviews: true` to temporarily lift the PR-review
> requirement during the push. Add `[skip ci]` to the bot commit message so
> the version-bump commit does not trigger redundant workflow runs.

</details>