### PR TITLE
Remove [skip ci] from bot commit message in CD release

### DIFF
--- a/.github/workflows/cd_release.yml
+++ b/.github/workflows/cd_release.yml
@@ -70,7 +70,7 @@ jobs:
       if: steps.update_version_step.outputs.continue_workflow == 'true'
       run: |
         git add app/__init__.py CHANGELOG.md
-        git commit -m "[bot] Update version and CHANGELOG [skip ci]"
+        git commit -m "[bot] Update version and CHANGELOG"
 
     - name: Update '${{ env.DEFAULT_REPO_BRANCH }}'
       if: steps.update_version_step.outputs.continue_workflow == 'true'


### PR DESCRIPTION
## Summary

- Removes `[skip ci]` from the `[bot] Update version and CHANGELOG` commit message in `cd_release.yml`.

## Why

`[skip ci]` in a commit message suppresses **all** CI runs triggered by that push — including runs on the `push-action/**` temp branch that `CasperWA/push-protected` creates while waiting for status checks to pass. With no CI running on the temp branch, `push-protected` finds 0 status check runs, immediately declares them "all complete," then attempts to push to `master` — which GitHub rejects with _"7 of 7 required status checks are expected"_.

Removing `[skip ci]` lets `ci_tests.yml` run normally on the `push-action/**` branch (it already has an explicit `push-action/**` trigger for exactly this purpose), allowing `push-protected` to wait for and confirm all required checks before pushing.

## Test plan

- [ ] Confirm the next CD release run completes successfully end-to-end (version bump commit → temp branch CI passes → push to master succeeds).
<details>
<summary>Click to view squash commit message</summary>

> Remove skip-ci token from bot commit message
>
> The skip-ci token suppresses CI on the push-action/** temp branch that
> push-protected creates, so GitHub finds 0 status check runs and
> immediately tries to merge — which then fails with "7 of 7 required
> status checks are expected".

</details>