### PR TITLE
Replace push-protected with direct push via TEAM4-0 bypass

### DIFF
--- a/.github/workflows/cd_release.yml
+++ b/.github/workflows/cd_release.yml
@@ -74,13 +74,9 @@ jobs:
 
     - name: Update '${{ env.DEFAULT_REPO_BRANCH }}'
       if: steps.update_version_step.outputs.continue_workflow == 'true'
-      uses: CasperWA/push-protected@v2
-      with:
-        token: ${{ secrets.RELEASE_PAT }}
-        branch: ${{ env.DEFAULT_REPO_BRANCH }}
-        pre_sleep: 15
-        force: false
-        unprotect_reviews: true
+      run: |
+        git remote set-url origin "https://TEAM4-0:${{ secrets.RELEASE_PAT }}@github.com/${{ github.repository }}.git"
+        git push origin ${{ env.DEFAULT_REPO_BRANCH }}
 
   publish_container_image:
     name: Publish Container image on GH Packages

--- a/.github/workflows/cd_release.yml
+++ b/.github/workflows/cd_release.yml
@@ -27,6 +27,7 @@ jobs:
       uses: actions/checkout@v6
       with:
         fetch-depth: 0
+        token: ${{ secrets.RELEASE_PAT }}
 
     - name: Set up git config
       run: |
@@ -74,9 +75,7 @@ jobs:
 
     - name: Update '${{ env.DEFAULT_REPO_BRANCH }}'
       if: steps.update_version_step.outputs.continue_workflow == 'true'
-      run: |
-        git remote set-url origin "https://TEAM4-0:${{ secrets.RELEASE_PAT }}@github.com/${{ github.repository }}.git"
-        git push origin ${{ env.DEFAULT_REPO_BRANCH }}
+      run: git push origin ${{ env.DEFAULT_REPO_BRANCH }}
 
   publish_container_image:
     name: Publish Container image on GH Packages

--- a/.github/workflows/ci_tests.yml
+++ b/.github/workflows/ci_tests.yml
@@ -5,7 +5,6 @@ on:
   push:
     branches:
       - 'master'
-      - 'push-action/**'  # Allow pushing to protected branches (using CasperWA/push-protected)
 
 jobs:
   pre-commit_audit:


### PR DESCRIPTION
## Summary

- Replaces `CasperWA/push-protected@v2` with a direct `git push` authenticated as TEAM4-0.
- `actions/checkout` now uses `token: RELEASE_PAT` so the persisted credential is already TEAM4-0's PAT — no remote URL manipulation needed.
- A repository ruleset (`master branch protection`, id 15349357) enforces the 6 required status checks on master with TEAM4-0 as an explicit always-bypass actor (configured out-of-band via the GitHub API).
- The classic branch protection's `required_status_checks` has been cleared (`enforcement_level: off`) so the ruleset is the sole enforcer.
- Removes the now-dead `push-action/**` branch trigger from `ci_tests.yml`.

## Why push-protected stopped working

`push-protected` works by pushing the commit to a temp `push-action/**` branch, waiting for CI to run there, then pushing to master. GitHub no longer triggers new workflow runs for pushes made from within a running workflow — even when using a PAT instead of `GITHUB_TOKEN`. As a result the temp branch CI never starts, `push-protected` declares all 0 jobs complete, and the push to master fails with `GH006: 6 of 6 required status checks are expected`.

## Why direct push now works

The new ruleset adds TEAM4-0 to the bypass list with `bypass_mode: always`. Because the checkout step persists RELEASE_PAT as the git credential, the subsequent `git push` is authenticated as TEAM4-0 and is exempt from the status check requirement. All other pushes (PR merges by humans) still require the 6 checks to pass.

## Test plan

- [ ] Merge this PR and confirm the next CD release run pushes the `[bot] Update version and CHANGELOG` commit to master without the `GH006` error.

<details>
<summary>Click to view squash commit message</summary>

> Replace push-protected with direct push via TEAM4-0 bypass
>
> The push-protected action relies on CI running on the push-action/**
> temp branch to satisfy required status checks before pushing to master.
> GitHub no longer triggers workflows for pushes made from within a
> running workflow, so the temp branch CI never runs, push-protected
> declares all checks vacuously complete, and the push fails.
>
> Instead, a repository ruleset now enforces required status checks on
> master with TEAM4-0 as an explicit bypass actor. The checkout step uses
> RELEASE_PAT so the persisted credential is already TEAM4-0's token,
> and the CD workflow pushes directly via `git push` — no remote URL
> manipulation needed.
>
> Also removes the dead push-action/** trigger from ci_tests.yml, which
> only existed to support push-protected's temp branches.

</details>