### PR TITLE
Amend latest commit instead of creating a new one for version bump

### DIFF
--- a/.github/workflows/cd_release.yml
+++ b/.github/workflows/cd_release.yml
@@ -71,11 +71,11 @@ jobs:
       if: steps.update_version_step.outputs.continue_workflow == 'true'
       run: |
         git add app/__init__.py CHANGELOG.md
-        git commit -m "[bot] Update version and CHANGELOG"
+        git commit --amend --no-edit
 
     - name: Update '${{ env.DEFAULT_REPO_BRANCH }}'
       if: steps.update_version_step.outputs.continue_workflow == 'true'
-      run: git push origin ${{ env.DEFAULT_REPO_BRANCH }}
+      run: git push --force origin ${{ env.DEFAULT_REPO_BRANCH }}
 
   publish_container_image:
     name: Publish Container image on GH Packages

--- a/.github/workflows/cd_release.yml
+++ b/.github/workflows/cd_release.yml
@@ -71,11 +71,11 @@ jobs:
       if: steps.update_version_step.outputs.continue_workflow == 'true'
       run: |
         git add app/__init__.py CHANGELOG.md
-        git commit --amend --no-edit
+        git commit --amend -C HEAD
 
     - name: Update '${{ env.DEFAULT_REPO_BRANCH }}'
       if: steps.update_version_step.outputs.continue_workflow == 'true'
-      run: git push --force origin ${{ env.DEFAULT_REPO_BRANCH }}
+      run: git push --force-with-lease origin ${{ env.DEFAULT_REPO_BRANCH }}
 
   publish_container_image:
     name: Publish Container image on GH Packages


### PR DESCRIPTION
## Summary

- Reverts the commit strategy from creating a new `[bot] Update version and CHANGELOG` commit back to **amending the triggering commit** with the version bump and changelog changes.
- Adds `--force-with-lease` to the push — required because the amended SHA differs from `origin/master`, and fails safely if another push has landed since checkout.
- Uses `git commit --amend -C HEAD` — preserves the original commit's **author** as well as message; the bot becomes committer only.

## Why amend instead of a new commit

The version's patch number is the total commit count. Creating a new commit increments that count, so the next CD run finds yet another version bump needed — an infinite loop. Amending the triggering commit leaves the count unchanged; the subsequent CD run sees no version change and exits cleanly.

The force-with-lease push is safe: `allow_force_pushes` is enabled on master via the ruleset admin bypass for TEAM4-0, so the push goes through. `--force-with-lease` adds an extra guard: if any concurrent push has landed since checkout, the push fails rather than silently overwriting it.

## Test plan

- [ ] Confirm that after merging, a push to master triggers one CD run that amends the head commit with the version bump, force-pushes, and stops — with no subsequent looping CD run.

<details>
<summary>Click to view squash commit message</summary>

> Amend latest commit instead of creating a new one
>
> The version's patch number equals the commit count. Creating a new
> commit changes that count, causing invoke setver to find another
> version bump on the next CD run — an infinite loop.
>
> Amending the triggering commit keeps the count unchanged, so the
> subsequent CD run finds no version change and stops.
>
> Uses `--amend -C HEAD` to preserve the original commit author (bot
> becomes committer only) and `--force-with-lease` to prevent
> overwriting any concurrent push that landed since checkout.

</details>